### PR TITLE
KAS-4711 add fix to query, add method to copy missing triples in target graph

### DIFF
--- a/.woodpecker/.feature.yml
+++ b/.woodpecker/.feature.yml
@@ -5,6 +5,6 @@ pipeline:
       repo: "${CI_REPO_OWNER%%-vlaanderen}/${CI_REPO_NAME}"
       tags: "feature-${CI_COMMIT_BRANCH##feature/}"
     secrets: [docker_username, docker_password]
-    when:
-      event: push
-      branch: feature/*
+when:
+  event: push
+  branch: feature/*

--- a/.woodpecker/.latest.yml
+++ b/.woodpecker/.latest.yml
@@ -5,6 +5,6 @@ pipeline:
       repo: "${CI_REPO_OWNER%%-vlaanderen}/${CI_REPO_NAME}"
       tags: latest
     secrets: [docker_username, docker_password]
-    when:
-      event: push
-      branch: [master, main]
+when:
+  event: push
+  branch: [master, main]

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -5,6 +5,6 @@ pipeline:
       repo: "${CI_REPO_OWNER%%-vlaanderen}/${CI_REPO_NAME}"
       tags: "${CI_COMMIT_TAG##v}"
     secrets: [ docker_username, docker_password ]
-    when:
-      event: tag
-      tag: v*
+when:
+  event: tag
+  tag: v*

--- a/lib/graph-helpers.js
+++ b/lib/graph-helpers.js
@@ -143,7 +143,7 @@ function toTripleStatement(triple) {
 *
 * @private
 */
-async function compareGraphAndCopyMissingTriples(source, target) {
+async function compareGraphAndCopyMissingTriples(source, target, retryCount=0) {
   // this is a copy of the yggdrasil code
   // this also works differently than the current method that gets a list of triples and copies just those
   // if that list is faulty for any reason this should get all the rest of the triples
@@ -156,7 +156,7 @@ async function compareGraphAndCopyMissingTriples(source, target) {
     }`);
   const count = parseInt(queryResult.results.bindings[0].count.value);
   if (count === 0) {
-    console.log('All triples were copied in target graph <${target}>, nothing to do');
+    console.log(`All triples were copied in target graph <${target}>, nothing to do`);
     return;
   }
   console.log(`${count} triples in graph <${source}> not found in target graph <${target}>. Going to copy these triples.`);
@@ -183,6 +183,13 @@ async function compareGraphAndCopyMissingTriples(source, target) {
       }`);
     currentBatch++;
   }
+  if (retryCount < 5) {
+    // This is where we could send an email to development team
+    console.log(`***!! Not all triples were copied in target graph after 5 retries !!***`);
+    return;
+  }
+  retryCount++;
+  await compareGraphAndCopyMissingTriples(source, target, retryCount);
 }
 
 /**

--- a/lib/graph-helpers.js
+++ b/lib/graph-helpers.js
@@ -183,7 +183,7 @@ async function compareGraphAndCopyMissingTriples(source, target, retryCount=0) {
       }`);
     currentBatch++;
   }
-  if (retryCount < 5) {
+  if (retryCount > 4) {
     // This is where we could send an email to development team
     console.log(`***!! Not all triples were copied in target graph after 5 retries !!***`);
     return;

--- a/lib/graph-helpers.js
+++ b/lib/graph-helpers.js
@@ -16,6 +16,11 @@ async function moveGraph(source, target) {
   const triples = await getTriples(source);
   console.log(`Copying triples from source graph <${source}> to target graph <${target}>`);
   await insertInGraph(triples, target);
+
+  // following an issue where not all triples were copied, implement an extra check and copy
+  console.log(`Verifying if all triples where moved`);
+  await compareGraph(source, target);
+
   console.log(`Removing triples from source graph <${source}>`);
   await removeGraph(source);
 }
@@ -48,7 +53,7 @@ async function getTriples(graph) {
           ?subject ?predicate ?object .
         }
       }
-      LIMIT ${SELECT_BATCH_SIZE} OFFSET %OFFSET
+      ORDER BY ?subject LIMIT ${SELECT_BATCH_SIZE} OFFSET %OFFSET
     `;
 
     while (offset < count) {
@@ -130,6 +135,54 @@ function toTripleStatement(triple) {
   const predicate = escape(triple.predicate);
   const object = escape(triple.object);
   return `${subject} ${predicate} ${object} .`;
+}
+
+/**
+* Verify all triples in the source graph were moved to the target graph
+* If not, do another copy of those triples
+*
+* @private
+*/
+async function compareGraph(source, target) {
+  // this is a copy of the yggdrasil code
+  // this also works differently than the current method that gets a list of triples and copies just those
+  // if that list is faulty for any reason this should get all the rest of the triples
+  const queryResult = await query(`
+    SELECT (COUNT(*) as ?count) WHERE {
+      GRAPH <${source}> { ?s ?p ?o . }
+      FILTER NOT EXISTS {
+        GRAPH <${target}> { ?s ?p ?o . }
+      }
+    }`);
+  const count = parseInt(queryResult.results.bindings[0].count.value);
+  if (count === 0) {
+    console.log('All triples were copied in target graph <${target}>, nothing to do');
+    return;
+  }
+  console.log(`${count} triples in graph <${source}> not found in target graph <${target}>. Going to copy these triples.`);
+  const limit = UPDATE_BATCH_SIZE;
+  const totalBatches = Math.ceil(count / limit);
+  console.log(`Copying ${count} triples in batches of ${UPDATE_BATCH_SIZE}`);
+  let currentBatch = 0;
+  while (currentBatch < totalBatches) {
+    console.log(`Copy triples (batch ${currentBatch + 1}/${totalBatches})`)
+      // Note: no OFFSET needed in the subquery. Pagination is inherent since
+      // the WHERE clause doesn't match any longer for triples that are copied in the previous batch.
+      await update(`
+      INSERT {
+        GRAPH <${target}> {
+          ?resource ?p ?o .
+        }
+      } WHERE {
+        SELECT ?resource ?p ?o WHERE {
+          GRAPH <${source}> { ?resource ?p ?o . }
+          FILTER NOT EXISTS {
+            GRAPH <${target}> { ?resource ?p ?o }
+          }
+        } LIMIT ${limit}
+      }`);
+    currentBatch++;
+  }
 }
 
 /**

--- a/lib/graph-helpers.js
+++ b/lib/graph-helpers.js
@@ -19,7 +19,7 @@ async function moveGraph(source, target) {
 
   // following an issue where not all triples were copied, implement an extra check and copy
   console.log(`Verifying if all triples where moved`);
-  await compareGraph(source, target);
+  await compareGraphAndCopyMissingTriples(source, target);
 
   console.log(`Removing triples from source graph <${source}>`);
   await removeGraph(source);
@@ -143,7 +143,7 @@ function toTripleStatement(triple) {
 *
 * @private
 */
-async function compareGraph(source, target) {
+async function compareGraphAndCopyMissingTriples(source, target) {
   // this is a copy of the yggdrasil code
   // this also works differently than the current method that gets a list of triples and copies just those
   // if that list is faulty for any reason this should get all the rest of the triples


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4711

Query with LIMIT and OFFSET without ORDER BY may lead to missing/duplicate triples if inherent pagination changes (may have happened twice in 2024, however I have no real proof of it at this time)
Fixed that query anyway. If it happens again we also have a backup now.

Added a method to check and copy triples missing in the target graph.
Looked at yggdrasil code for inspiration and blatant copies of code.

Was wondering If I could count or verify if the amount of docs results in the right amount of distributions.
But that was not the issue, we had all the distributions. Not all triples of those were copied.
Since some of those triples are optional it is hard to calculate exactly how many triples a dataset should contain.
The new copy method should in theory always get the missing triples.
Very simple query that should not fail to copy the data so further checks may not be needed?


